### PR TITLE
preloading

### DIFF
--- a/lib/fn/index.js
+++ b/lib/fn/index.js
@@ -144,7 +144,7 @@ export async function getProvider(ioOpts, defaultProvider) {
 /** Wrapper for setInterval, clearInterval, and setImmediate. This is necessary so we can use the Global methods in node.js and the System methods in XS.
  * @namespace timer
  */
-export const timer = {
+export const timer = Object.freeze({
 
   /**
    * Execute a callback on a recurring interval
@@ -275,7 +275,7 @@ export const timer = {
     }
   }
 
-};
+});
 
 /** Debounce a function so that it is not invoked unless it stops being called for N milliseconds
  * @function debounce

--- a/lib/fn/manifest.json
+++ b/lib/fn/manifest.json
@@ -4,7 +4,9 @@
     "*": [],
     "j5e/fn": "$(j5e)/lib/fn/*"
   },
-  "preload": [],
+  "preload": [
+    "j5e/fn"
+  ],
   "platforms": {
     "esp": {},
     "...": {

--- a/lib/led/manifest.json
+++ b/lib/led/manifest.json
@@ -8,7 +8,13 @@
     "j5e/led": "$(j5e)/lib/led/*",
     "j5e/event": "$(j5e)/lib/event/*"
   },
-  "preload": [],
+  "preload": [
+    "j5e/animation",
+    "j5e/easing",
+    "j5e/fn",
+    "j5e/led",
+    "j5e/event"
+  ],
   "platforms": {
     "esp": {},
     "...": {


### PR DESCRIPTION
Enabled preloading for the `fn` and `led` modules. This saves memory by moving the class and functions from memory to flash. It also speeds start-up. If this works for you, the same should be applied to other modules.

The change to freeze the timer object saves an entry in the alias table (and eliminates a build warning when preloading `fn`). 