### PR TITLE
Fix TC53 global name

### DIFF
--- a/build/docs/tutorials/C-INSTANTIATING.md
+++ b/build/docs/tutorials/C-INSTANTIATING.md
@@ -16,7 +16,7 @@ In code a provider is a bundle of classes that work with that "thing". Providers
 In TC-53 parlance, an "IO" is a single GPIO (General-Purpose Input/Output) instance. That GPIO Instance could be Digital, PWM, Serial, I2C, SPI or something else. **The ```ioOptions``` options object describes the configuration for the IO instance**. This configuration could include which board to use, which pins, what data rate, etc. The details depend on your situation and provider. 
 
 The options argument is always required and can take a few different forms: 
-* **Pin Identifier** - This is the simplest scenario and would be a single number or string. J5e will assume the provider is built into the Host.io global. The particular type of IO you need will vary by device type. For example, servo would default to ```Host.io.PWM```. Button or switch would default to ```Host.io.Digital```.
+* **Pin Identifier** - This is the simplest scenario and would be a single number or string. J5e will assume the provider is built into the device.io global. The particular type of IO you need will vary by device type. For example, servo would default to ```device.io.PWM```. Button or switch would default to ```device.io.Digital```.
   ````js
   import LED from "j5e/led";
 

--- a/docs/fn_index.js.html
+++ b/docs/fn_index.js.html
@@ -249,7 +249,7 @@ export async function getProvider(ioOpts, ioType) {
  * @ignore
  */
 export async function defaultProvider(ioType) {
-  let defaultProvider = Host.io;
+  let defaultProvider = device.io;
   return defaultProvider[ioType];
 }
 

--- a/docs/tutorial-C-INSTANTIATING.html
+++ b/docs/tutorial-C-INSTANTIATING.html
@@ -109,7 +109,7 @@
 <p>The options argument is always required and can take a few different forms:</p>
 <ul>
 <li>
-<p><strong>Pin Identifier</strong> - This is the simplest scenario and would be a single number or string. J5e will assume the provider is built into the Host.io global. The particular type of IO you need will vary by device type. For example, servo would default to <code>Host.io.PWM</code>. Button or switch would default to <code>Host.io.Digital</code>.</p>
+<p><strong>Pin Identifier</strong> - This is the simplest scenario and would be a single number or string. J5e will assume the provider is built into the device.io global. The particular type of IO you need will vary by device type. For example, servo would default to <code>device.io.PWM</code>. Button or switch would default to <code>device.io.Digital</code>.</p>
 <pre class="prettyprint source lang-js"><code>import LED from &quot;j5e/led&quot;;
 
 // Instantiate an LED connected to 

--- a/lib/fn/index.js
+++ b/lib/fn/index.js
@@ -154,7 +154,7 @@ export async function getProvider(ioOpts, ioType) {
  * @ignore
  */
 export async function defaultProvider(ioType) {
-  let defaultProvider = Host.io;
+  let defaultProvider = device.io;
   return defaultProvider[ioType];
 }
 


### PR DESCRIPTION
```Host.io``` was recently changed to ```device.io``` which breaks j5e as discussed in #93 