### PR TITLE
Fix document LED.blink params is optional.

### DIFF
--- a/lib/led/index.js
+++ b/lib/led/index.js
@@ -196,8 +196,8 @@ class LED {
 
   /**
    * Blink the LED on a fixed interval
-   * @param {Number} duration=100 - Time in ms on, time in ms off
-   * @param {Function} callback - Method to call on blink
+   * @param {Number} [duration=100] - Time in ms on, time in ms off
+   * @param {Function} [callback] - Method to call on blink
    * @return {LED}
    * @example
    * import LED from "j5e/led";


### PR DESCRIPTION
Fixed an error when using with allowJs at typescript

current
![image](https://user-images.githubusercontent.com/6237028/156920109-74301147-1d3a-461f-9d4d-80818b09cc5e.png)

patched
![image](https://user-images.githubusercontent.com/6237028/156920082-34ecb656-8584-4127-9413-c906c8f3ac4c.png)
