### PR TITLE
fix fn/getIO and normalizeIO maby not works.

### DIFF
--- a/lib/fn/index.js
+++ b/lib/fn/index.js
@@ -18,12 +18,12 @@ export async function getIO(ioOpts, ioDefaults) {
   //     this.trigger();
   //   }
   // });
-  if (typeof ioDefaults === "String") {
+  if (typeof ioDefaults === "string") {
     ioDefaults = {
       type: ioDefaults
     };
   }
-  if (ioOpts.constructor.name !== "Object") {
+  if (typeof ioOpts === "object" && ioOpts.constructor.name !== "Object") {
     // This is an IO instance
     return ioOpts;
   }
@@ -59,7 +59,7 @@ export function normalizeIO(ioOptions = null, ioDefaults = {}) {
   }
 
   if (typeof ioOptions === "number" || typeof ioOptions === "string") {
-    ioOptions = { ioOptions };
+    ioOptions = { pin: ioOptions };
   }
   if (typeof ioDefaults === "number" || typeof ioDefaults === "string") {
     ioDefaults = { mode: ioDefaults };


### PR DESCRIPTION
Fix tutorial code not working.
-----------------------------------
https://dtex.github.io/j5e/tutorial-C-INSTANTIATING.html

tutorial says:
```javascript
import LED from "j5e/led";

// Instantiate an LED connected to
// builtin pin 13
const led = await new LED(13);

led.blink();
```
but I got error. ( # Break: (host): async module!)   

then fix to this.
my code:
```javascript
import LED from "j5e/led";

export default async function() {
  // Instantiate an LED connected to
  // builtin pin 13
  const led = await new LED(13);

  led.blink();
}
```
but I got error. (LED.prototype.write: no function!)
![image](https://user-images.githubusercontent.com/6237028/157657962-c7e67b9c-8616-4dac-aa4b-2d202b566e2a.png)

#### behavior
```
new LED(13) -> LED constructor ->  pass 13 to fn.getIO ->    
   (13).constructor.name !== "Object"  then  return 13.  
  io = 13.    
  (13).write no function!  
```

### fix
getIO ioOpts description says:   
`ioOpts - A pin number, pin identifier or a complete IO options object`  
change:  if typeof ioOpts not object then pass to normalizeIO. 

but next error.
![image](https://user-images.githubusercontent.com/6237028/157664683-999bf73e-0c8c-4346-91e4-2321fab85979.png)

### fix
```javascript
typeof ioDefaults === "string"
```

next error.
![image](https://user-images.githubusercontent.com/6237028/157665636-ab66c658-37c1-493d-aad0-dbe56439bdc9.png)

### fix
normalizeIO
```javascript
// ioOptions = { ioOptions}   // <--- wrong ? change to
ioOptions = { pin: ioOptions }
```

then  

works fine!